### PR TITLE
Removed egrader from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ Mako==1.0.4
 MarkupSafe==0.23
 nltk==3.2.1
 numpy==1.11.1
-openstax-egrader==0.1.3
 pandas==0.18.1
 paramiko==2.0.2
 passlib==1.6.5


### PR DESCRIPTION
Deployment tasks are failing as they can't find egrader in pypi.
The egrader does not need to be in the requirements file.
