### PR TITLE
fixed the not qualified button

### DIFF
--- a/eGrader/api/endpoints.py
+++ b/eGrader/api/endpoints.py
@@ -119,6 +119,9 @@ def submit_grader_response():
 @api.route('/exercise/unqualified', methods=['POST'])
 @login_required
 def not_qualified():
+    if 'exercise_id' in session and session['exercise_id']:
+        del session['exercise_id']
+
     posted = request.get_json()
     unqual = UserUnqualifiedExercise(
         user_id = posted['user_id'],


### PR DESCRIPTION
the not qualified button in the grader form was not causing a new
exercise to be loaded. I added a check on the unqualified api endpoint
to check the session for an exercise id and to clear it if one exists.

fixes #70 