### PR TITLE
added no cache to response header

### DIFF
--- a/eGrader/grader/views.py
+++ b/eGrader/grader/views.py
@@ -8,7 +8,7 @@ from flask_security import current_user
 from flask_socketio import emit
 
 from eGrader.grader.forms import GraderForm
-from eGrader.utils import send_slack_msg
+from eGrader.utils import render_template_no_cache, send_slack_msg
 from ..core import db, socketio
 
 from .models import (Exercise,
@@ -109,7 +109,7 @@ def _get_exercise_response():
 @grader.route('/', methods=['GET'])
 @login_required
 def index():
-    return render_template('grader_index.html',
+    return render_template_no_cache('grader_index.html',
                            user_id=current_user.id)
 
 
@@ -117,6 +117,7 @@ def index():
 @login_required
 def old():
     """
+    * DEPRECATED *
     This view is deprecated as it was only used to test javascript and algorithms. This
     form allows you to submit responses simply using html forms and nothing more and is
     not as sophisticated as `grader.index`

--- a/eGrader/utils.py
+++ b/eGrader/utils.py
@@ -7,11 +7,26 @@ import requests
 import sqlalchemy as db
 from datetime import datetime
 
-from flask import current_app, Response
+from flask import (current_app,
+                   make_response,
+                   render_template,
+                   Response)
 
 from eGrader.exceptions import api_error_handler
 from jinja2 import Markup
 from sqlalchemy.sql.expression import extract
+
+
+def no_cache(response):
+    response.headers.add(
+        'Cache-Control',
+        'no-store, no-cache, must-revalidate, post-check=0, pre-check=0')
+    return response
+
+
+def render_template_no_cache(*args, **kwargs):
+    response = make_response(render_template(*args, **kwargs))
+    return no_cache(response)
 
 
 def to_csv(field_names, collection):

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ Mako==1.0.6
 MarkupSafe==0.23
 nltk==3.2.1
 numpy==1.11.2
-openstax-egrader==0.1.4
 pandas==0.19.1
 paramiko==2.0.2
 passlib==1.7.0


### PR DESCRIPTION
updated changes to javascript have caused issues with some user's browsers.
I've added a render_template_no_cache function that modifies the response header to signal
the browser not to cache any static files.