### PR TITLE
fixed the selection of get next unresolved response and misconception…

### DIFF
--- a/eGrader/static/js/app/main.js
+++ b/eGrader/static/js/app/main.js
@@ -271,13 +271,18 @@ var App = {
 
                 // See which item is checked
                 let $checked = $("input[name='misconception']:checked");
+                console.log($checked.val());
+                console.log($explanation);
 
                 if ($checked.val() == 't' && $explanation.length > 0) {
-                    console.log('there is an explanation!');
+                    console.log('Explanation provided for misconception');
+                  return true
+                } else if ($checked.val() == 'n'){
+                    console.log('Misconception is false');
                   return true
                 } else {
-                    console.log('This is fail!!!');
-                  return false
+                    this.notifyError('There was an error. Please enter an explanation for the misconception');
+                    return false
                 }
 
             }


### PR DESCRIPTION
… field

- misconception field wasn't properly detecting that it was set to false. This kept the user from submitting the form.
- An exercise was returning there was an unresolved response, however, when executing the get_next_unresolved_response function nothing was being returned. This was fixed.