### PR TITLE
fixed subquery in get_next_exercise function

### DIFF
--- a/eGrader/grader/models.py
+++ b/eGrader/grader/models.py
@@ -217,7 +217,7 @@ def get_next_exercise_id(user_id, subject_id, chapter_id=None):
     # The unqualified subquery used to remove any exercises the grader is
     # marked as unqualified to grade.
     unqual_subq = db.session.query(UserUnqualifiedExercise.exercise_id) \
-            .filter(UserGradingSession.user_id == user_id).subquery()
+            .filter(UserUnqualifiedExercise.user_id == user_id).subquery()
 
     # The main query that gets distinct counts of all grader criteria
     g_count = db.session.query(Exercise.id.label('exercise_id'),


### PR DESCRIPTION
the subquery was pointing to a table that was incorrect. this caused the performance of the query to become quite poor when there were no more unresolved responses.